### PR TITLE
Remove try link on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,7 +66,7 @@
     <div class="caption">
       <div class="text-center">
         <h1>The shell for the Java Platform <br/>Open source and <span>open</span> minded</h1>
-        <a href="http://try.crashub.org" class="btn btn-primary">Try Now </a>
+<!--        <a href="http://try.crashub.org" class="btn btn-primary">Try Now </a> -->
       </div>
     </div>
   </section> <!-- end banner -->


### PR DESCRIPTION
To be restored when try.crash.org finds a new home
